### PR TITLE
[Feat/Fix] (Fix/Feat IOS Hidden SubDirectories pictures) (Fix TIFF AND HEIC is not implemented) (Feat add counter in Collections)

### DIFF
--- a/src/android/Photos.java
+++ b/src/android/Photos.java
@@ -69,6 +69,7 @@ public class Photos extends CordovaPlugin {
 	private static final String P_DATE = "date";
 	private static final String P_TS = "timestamp";
 	private static final String P_TYPE = "contentType";
+    private static final String P_COUNT = "count";
 
 	private static final String P_SIZE = "dimension";
 	private static final String P_QUALITY = "quality";
@@ -108,7 +109,7 @@ public class Photos extends CordovaPlugin {
 
 	@SuppressWarnings("MismatchedReadAndWriteOfArray")
 	private static final String[] PRJ_COLLECTIONS =
-			new String[]{"DISTINCT " + BUCKET_ID, BUCKET_DISPLAY_NAME};
+			new String[]{"DISTINCT " + BUCKET_ID, BUCKET_DISPLAY_NAME, SIZE};
 
 	@SuppressWarnings("MismatchedReadAndWriteOfArray")
 	private static final String[] PRJ_PHOTOS =
@@ -221,7 +222,20 @@ public class Photos extends CordovaPlugin {
 					final JSONObject item = new JSONObject();
 					item.put(P_ID, cursor.getString(cursor.getColumnIndex(BUCKET_ID)));
 					item.put(P_NAME, cursor.getString(cursor.getColumnIndex(BUCKET_DISPLAY_NAME)));
-					result.put(item);
+                    item.put(P_COUNT, "1");
+
+                    JSONObject element = null;
+                    for (int i = 0; i < result.length(); i++) {
+                        if (result.getJSONObject(i).getString(P_ID).equalsIgnoreCase(item.getString(P_ID))){
+                            element = result.getJSONObject(i);
+                            break;
+                        }
+                    }
+                    if (element == null) {
+					    result.put(item);
+                    } else {
+                        element.put(P_COUNT, Integer.parseInt(element.getString(P_COUNT)) + 1);
+                    }
 				} while (cursor.moveToNext());
 			}
 			callbackContext.success(result);
@@ -244,8 +258,8 @@ public class Photos extends CordovaPlugin {
 			selection = BUCKET_ID + " IN (" + repeatText(collectionIds.length(), "?", ",") + ")";
 			selectionArgs = this.<String>jsonArrayToList(collectionIds).toArray(new String[collectionIds.length()]);
 		} else {
-			selection = BUCKET_DISPLAY_NAME + "=?";
-			selectionArgs = new String[]{BN_CAMERA};
+			selection = null;//BUCKET_DISPLAY_NAME + "=?";
+			selectionArgs = null;//new String[]{BN_CAMERA};
 		}
 
 		final int offset = options != null ? options.optInt(P_LIST_OFFSET, 0) : 0;

--- a/src/android/Photos.java
+++ b/src/android/Photos.java
@@ -69,7 +69,7 @@ public class Photos extends CordovaPlugin {
 	private static final String P_DATE = "date";
 	private static final String P_TS = "timestamp";
 	private static final String P_TYPE = "contentType";
-    private static final String P_COUNT = "count";
+        private static final String P_COUNT = "count";
 
 	private static final String P_SIZE = "dimension";
 	private static final String P_QUALITY = "quality";
@@ -109,7 +109,7 @@ public class Photos extends CordovaPlugin {
 
 	@SuppressWarnings("MismatchedReadAndWriteOfArray")
 	private static final String[] PRJ_COLLECTIONS =
-			new String[]{"DISTINCT " + BUCKET_ID, BUCKET_DISPLAY_NAME, SIZE};
+			new String[]{BUCKET_ID, BUCKET_DISPLAY_NAME, SIZE};
 
 	@SuppressWarnings("MismatchedReadAndWriteOfArray")
 	private static final String[] PRJ_PHOTOS =

--- a/src/android/Photos.java
+++ b/src/android/Photos.java
@@ -258,8 +258,8 @@ public class Photos extends CordovaPlugin {
 			selection = BUCKET_ID + " IN (" + repeatText(collectionIds.length(), "?", ",") + ")";
 			selectionArgs = this.<String>jsonArrayToList(collectionIds).toArray(new String[collectionIds.length()]);
 		} else {
-			selection = null;//BUCKET_DISPLAY_NAME + "=?";
-			selectionArgs = null;//new String[]{BN_CAMERA};
+			selection = null;
+			selectionArgs = null;
 		}
 
 		final int offset = options != null ? options.optInt(P_LIST_OFFSET, 0) : 0;

--- a/src/ios/CDVPhotos.m
+++ b/src/ios/CDVPhotos.m
@@ -103,7 +103,7 @@ NSString* const S_SORT_TYPE = @"creationDate";
     CDVPhotos* __weak weakSelf = self;
     [self checkPermissionsOf:command andRun:^{
         NSDictionary* options = [weakSelf argOf:command atIndex:0 withDefault:@{}];
-
+        
         PHFetchResult<PHAssetCollection*>* fetchResultAssetCollections
         = [weakSelf fetchCollections:options];
         if (fetchResultAssetCollections == nil) {
@@ -116,15 +116,17 @@ NSString* const S_SORT_TYPE = @"creationDate";
 
         [fetchResultAssetCollections enumerateObjectsUsingBlock:
          ^(PHAssetCollection* _Nonnull assetCollection, NSUInteger idx, BOOL* _Nonnull stop) {
+            NSString* count = [@(assetCollection.estimatedAssetCount) stringValue];
+            NSString* title = assetCollection.localizedTitle;
+            if ([weakSelf isNull:assetCollection.localizedTitle]) {
+                title = DEF_NAME;
+            }
              NSMutableDictionary<NSString*, NSObject*>* collectionItem
              = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                 assetCollection.localIdentifier, P_ID,
-                assetCollection.localizedTitle, P_NAME,
-                assetCollection.estimatedAssetCount == NSNotFound ? I_ZERO : [NSString stringWithFormat:@"%lu",assetCollection.estimatedAssetCount], P_COUNT,
+                title, P_NAME,
+                count, P_COUNT,
                 nil];
-             if ([weakSelf isNull:assetCollection.localizedTitle]) {
-                 collectionItem[P_NAME] = DEF_NAME;
-             }
 
              [result addObject:collectionItem];
          }];
@@ -367,9 +369,12 @@ NSString* const S_SORT_TYPE = @"creationDate";
     } else {
         return nil;
     }
+    PHFetchOptions* fetchOptions = [[PHFetchOptions alloc] init];
+    fetchOptions.includeHiddenAssets = FALSE;
+    
     return [PHAssetCollection fetchAssetCollectionsWithType:type
                                                     subtype:subtype
-                                                    options:nil];
+                                                    options:fetchOptions];
 }
 
 - (NSMutableArray<NSDictionary*>*) fetchAllAssets {

--- a/src/ios/CDVPhotos.m
+++ b/src/ios/CDVPhotos.m
@@ -283,10 +283,22 @@ NSString* const S_SORT_TYPE = @"creationDate";
                  return;
              }
              UIImage* image = [UIImage imageWithData:imageData];
-             NSData* mediaData = UIImageJPEGRepresentation(image, 1);// only JPEG Representation
+             UIImage* imageOriented = [weakSelf rotateUIImage:image orientation:orientation];
+             NSData* mediaData = UIImageJPEGRepresentation(imageOriented, 1);// only JPEG Representation
              [weakSelf success:command withData:mediaData];
          }];
     }];
+}
+
+- (UIImage*)rotateUIImage:(UIImage*)sourceImage orientation:(UIImageOrientation)orientation
+{
+    CGSize size = sourceImage.size;
+    UIGraphicsBeginImageContext(CGSizeMake(size.height, size.width));
+    [[UIImage imageWithCGImage:[sourceImage CGImage] scale:1.0 orientation:orientation] drawInRect:CGRectMake(0,0,size.width ,size.height)];
+    UIImage* newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+
+    return newImage;
 }
 
 - (void) cancel:(CDVInvokedUrlCommand*)command {

--- a/src/ios/CDVPhotos.m
+++ b/src/ios/CDVPhotos.m
@@ -422,6 +422,10 @@ NSString* const S_SORT_TYPE = @"creationDate";
     fetchOptions.includeAllBurstAssets = YES;
     fetchOptions.includeHiddenAssets = YES;
     
+    if (offset == 0) {
+        fetchOptions.fetchLimit = limit;
+    }
+    
     PHFetchResult<PHAsset *> * fetchResultAssets = [PHAsset fetchAssetsWithMediaType:PHAssetMediaTypeImage options:fetchOptions];
     
     int __block fetched = 0;
@@ -463,8 +467,8 @@ NSString* const S_SORT_TYPE = @"creationDate";
                         }
                         [result addObject:assetItem];
                         if (limit > 0 && result.count >= limit) {
-                            [weakSelf partial:self.photosCommand withArray:result];
-                            [result removeAllObjects];
+                            *stop = YES;
+                            return ;
                         }
                     }
                     ++fetched;
@@ -562,6 +566,7 @@ NSString* const S_SORT_TYPE = @"creationDate";
                                   }
                                   [result addObject:assetItem];
                                   if (limit > 0 && result.count >= limit) {
+                                      *stop = YES;
                                       return ;
                                   }
                               }

--- a/src/ios/CDVPhotos.m
+++ b/src/ios/CDVPhotos.m
@@ -282,7 +282,9 @@ NSString* const S_SORT_TYPE = @"creationDate";
                  [weakSelf failure:command withMessage:E_PHOTO_NO_DATA];
                  return;
              }
-             [weakSelf success:command withData:imageData];
+             UIImage* image = [UIImage imageWithData:imageData];
+             NSData* mediaData = UIImageJPEGRepresentation(image, 1);// only JPEG Representation
+             [weakSelf success:command withData:mediaData];
          }];
     }];
 }

--- a/src/ios/CDVPhotos.m
+++ b/src/ios/CDVPhotos.m
@@ -293,16 +293,11 @@ NSString* const S_SORT_TYPE = @"creationDate";
 - (UIImage*)rotateUIImage:(UIImage*)sourceImage orientation:(UIImageOrientation)orientation
 {
     CGSize size = sourceImage.size;
-    CGFloat width = size.width;
-    CGFloat height = size.height;
     
     switch (orientation) {
         case UIImageOrientationDown:          // 180 deg rotation
-            break ;
         case UIImageOrientationLeft:          // 90 deg CCW
         case UIImageOrientationRight:         // 90 deg CW
-            width = size.height;
-            height = size.width;
             break ;
         case UIImageOrientationUp:            // default orientation
         case UIImageOrientationUpMirrored:    // as above but image mirrored along other axis. horizontal flip
@@ -311,8 +306,8 @@ NSString* const S_SORT_TYPE = @"creationDate";
         case UIImageOrientationRightMirrored: // vertical flip
             return sourceImage;
     }
-    UIGraphicsBeginImageContext(CGSizeMake(width, height));
-    [[UIImage imageWithCGImage:[sourceImage CGImage] scale:1.0 orientation:orientation] drawInRect:CGRectMake(0,0,width,height)];
+    UIGraphicsBeginImageContext(CGSizeMake(size.width, size.height));
+    [[UIImage imageWithCGImage:[sourceImage CGImage] scale:1.0 orientation:orientation] drawInRect:CGRectMake(0,0,size.width,size.height)];
     UIImage* newImage = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
 

--- a/src/ios/CDVPhotos.m
+++ b/src/ios/CDVPhotos.m
@@ -42,6 +42,7 @@ NSString* const P_LON = @"longitude";
 NSString* const P_DATE = @"date";
 NSString* const P_TS = @"timestamp";
 NSString* const P_TYPE = @"contentType";
+NSString* const P_COUNT = @"count";
 
 NSString* const P_SIZE = @"dimension";
 NSString* const P_QUALITY = @"quality";
@@ -119,6 +120,7 @@ NSString* const S_SORT_TYPE = @"creationDate";
              = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                 assetCollection.localIdentifier, P_ID,
                 assetCollection.localizedTitle, P_NAME,
+                assetCollection.estimatedAssetCount, P_COUNT,
                 nil];
              if ([weakSelf isNull:assetCollection.localizedTitle]) {
                  collectionItem[P_NAME] = DEF_NAME;

--- a/src/ios/CDVPhotos.m
+++ b/src/ios/CDVPhotos.m
@@ -116,7 +116,7 @@ NSString* const S_SORT_TYPE = @"creationDate";
         [fetchResultCollections enumerateObjectsUsingBlock:
         ^(PHCollection* _Nonnull collection, NSUInteger idx, BOOL* _Nonnull stop) {
             if ([collection isKindOfClass:PHCollectionList.class]) {
-                //Skip directories
+                //Skip album directories
                 [array addObject:(PHAssetCollection*)collection];
             } else {
                 [array addObject:(PHAssetCollection*)collection];
@@ -127,7 +127,7 @@ NSString* const S_SORT_TYPE = @"creationDate";
         
         for (PHCollection* collection in array) {
             if ([collection isKindOfClass:PHCollectionList.class]) {
-                //Skip directories
+                //Skip album directories
             } else {
                 assetCollectionCount++;
             }
@@ -138,7 +138,7 @@ NSString* const S_SORT_TYPE = @"creationDate";
         
         for (PHCollection* collection in array) {
             if ([collection isKindOfClass:PHCollectionList.class]) {
-                //Skip directories
+                //Skip album directories
             } else {
                 PHAssetCollection* assetCollection = (PHAssetCollection*)collection;
                 NSString* count = [@(assetCollection.estimatedAssetCount) stringValue];
@@ -411,8 +411,6 @@ NSString* const S_SORT_TYPE = @"creationDate";
     int limit = [[weakSelf valueFrom:options
                                byKey:P_LIST_LIMIT
                          withDefault:@"0"] intValue];
-    
-    //PHImageRequestOptions* reqOptions = [[PHImageRequestOptions alloc] init];
     
     PHFetchOptions* fetchOptions = [[PHFetchOptions alloc] init];
     NSMutableArray<NSSortDescriptor*> * descriptors = [NSMutableArray array];

--- a/src/ios/CDVPhotos.m
+++ b/src/ios/CDVPhotos.m
@@ -116,7 +116,7 @@ NSString* const S_SORT_TYPE = @"creationDate";
         [fetchResultCollections enumerateObjectsUsingBlock:
         ^(PHCollection* _Nonnull collection, NSUInteger idx, BOOL* _Nonnull stop) {
             if ([collection isKindOfClass:PHCollectionList.class]) {
-                //Skip album directories
+                //Skip album sub directories
                 [array addObject:(PHAssetCollection*)collection];
             } else {
                 [array addObject:(PHAssetCollection*)collection];
@@ -127,7 +127,7 @@ NSString* const S_SORT_TYPE = @"creationDate";
         
         for (PHCollection* collection in array) {
             if ([collection isKindOfClass:PHCollectionList.class]) {
-                //Skip album directories
+                //Skip album sub directories
             } else {
                 assetCollectionCount++;
             }
@@ -138,7 +138,7 @@ NSString* const S_SORT_TYPE = @"creationDate";
         
         for (PHCollection* collection in array) {
             if ([collection isKindOfClass:PHCollectionList.class]) {
-                //Skip album directories
+                //Skip album sub directories
             } else {
                 PHAssetCollection* assetCollection = (PHAssetCollection*)collection;
                 NSString* count = [@(assetCollection.estimatedAssetCount) stringValue];

--- a/src/ios/CDVPhotos.m
+++ b/src/ios/CDVPhotos.m
@@ -293,8 +293,26 @@ NSString* const S_SORT_TYPE = @"creationDate";
 - (UIImage*)rotateUIImage:(UIImage*)sourceImage orientation:(UIImageOrientation)orientation
 {
     CGSize size = sourceImage.size;
-    UIGraphicsBeginImageContext(CGSizeMake(size.height, size.width));
-    [[UIImage imageWithCGImage:[sourceImage CGImage] scale:1.0 orientation:orientation] drawInRect:CGRectMake(0,0,size.width ,size.height)];
+    CGFloat width = size.width;
+    CGFloat height = size.height;
+    
+    switch (orientation) {
+        case UIImageOrientationDown:          // 180 deg rotation
+            break ;
+        case UIImageOrientationLeft:          // 90 deg CCW
+        case UIImageOrientationRight:         // 90 deg CW
+            width = size.height;
+            height = size.width;
+            break ;
+        case UIImageOrientationUp:            // default orientation
+        case UIImageOrientationUpMirrored:    // as above but image mirrored along other axis. horizontal flip
+        case UIImageOrientationDownMirrored:  // horizontal flip
+        case UIImageOrientationLeftMirrored:  // vertical flip
+        case UIImageOrientationRightMirrored: // vertical flip
+            return sourceImage;
+    }
+    UIGraphicsBeginImageContext(CGSizeMake(width, height));
+    [[UIImage imageWithCGImage:[sourceImage CGImage] scale:1.0 orientation:orientation] drawInRect:CGRectMake(0,0,width,height)];
     UIImage* newImage = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
 

--- a/src/ios/CDVPhotos.m
+++ b/src/ios/CDVPhotos.m
@@ -120,7 +120,7 @@ NSString* const S_SORT_TYPE = @"creationDate";
              = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                 assetCollection.localIdentifier, P_ID,
                 assetCollection.localizedTitle, P_NAME,
-                assetCollection.estimatedAssetCount, P_COUNT,
+                assetCollection.estimatedAssetCount == NSNotFound ? I_ZERO : [NSString stringWithFormat:@"%lu",assetCollection.estimatedAssetCount], P_COUNT,
                 nil];
              if ([weakSelf isNull:assetCollection.localizedTitle]) {
                  collectionItem[P_NAME] = DEF_NAME;


### PR DESCRIPTION
DOMAX-01 BUG: IOS subCollections is visible but not undertandable.
DOMAX-01 Fix/Feat: for P_C_MODE_ALBUMS implement PHCollectionList from Apple documentation use method fetchTopLevelUserCollectionsWithOptions https://developer.apple.com/documentation/photokit/phcollection/1618513-fetchtoplevelusercollectionswith?language=occ and hidde subdirectories pictures for comprehension.
 
DOMAX-02 BUG: ios the pictures TIFF AND HEIC is not implemented
DOMAX-02 Fix: IOS add picture formats @"TIFF": @"image/tiff", @"HEIC": @"image/png"

DOMAX-03 Feat: IOS/Android Adding approximative counter picture in collections

DOMAX-04 Feat: in IOS and Android empty array in arg0 to getPhotos return all albums photos

DOMAX-05 Feat: remove auto recall callback for compréhension.

DOMAX-06 BUG: ios the pictures HEIC not working in images function getting
DOMAX-06 Fix: ios Only getting JPEGRepresentation with best quality on images function  

DOMAX-07 BUG: ios the images is not automaticaly oriented to the good direction
DOMAX-07 Fix: ios at the end of getting images set the orientation to the good direction